### PR TITLE
Increase file size limit to 100MB

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -409,7 +409,7 @@ int main (int argc, char **argv) {
 
 	fsize = st.st_size;
 
-	if (fsize < 512 || fsize > 20 * 1024 * 1024) {
+	if (fsize < 512 || fsize > 100 * 1024 * 1024) {
 		close (fd);
 		fprintf (stderr, "error: invalid file size\n");
 		exit (EXIT_FAILURE);


### PR DESCRIPTION
Hit this limit when trying to start debug builds of RetroArch on WiiU: Those binaries are currently around 23MB in size, so the current limit is not enough.
