### PR TITLE
Exit with non-zero code when upload fails

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -524,6 +524,6 @@ int main (int argc, char **argv) {
 
 	free (buf);
 
-	return 0;
+	return res ? 0 : 1;
 }
 


### PR DESCRIPTION
I have some tooling that automatically attempts to upload code to a Wii for testing, but it will sometimes randomly fail to send. Unfortunately, without this patch, it's not trivial to detect that failure.